### PR TITLE
Local PTY: bound write back-pressure (deadlock fix) and coalesce read callbacks

### DIFF
--- a/Sources/Termini/TerminiLocalPTYProcess.swift
+++ b/Sources/Termini/TerminiLocalPTYProcess.swift
@@ -145,6 +145,12 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
             payload.withUnsafeBytes { bytes in
                 guard var cursor = bytes.bindMemory(to: UInt8.self).baseAddress else { return }
                 var remaining = bytes.count
+                // Bound the back-pressure wait: if the reader (e.g. a stalled SSH
+                // link) never drains, give up rather than spin forever. An unbounded
+                // wait here wedges this serial queue, which would deadlock a
+                // `queue.sync` caller such as `terminate()` — hanging app shutdown.
+                var stalledMicros = 0
+                let maxStallMicros = 1_000_000
 
                 while remaining > 0 {
                     let written = Darwin.write(self.masterFileDescriptor, cursor, remaining)
@@ -152,10 +158,13 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
                     if written > 0 {
                         remaining -= written
                         cursor = cursor.advanced(by: written)
+                        stalledMicros = 0
                     } else if written == -1 && errno == EINTR {
                         continue
                     } else if written == -1 && (errno == EAGAIN || errno == EWOULDBLOCK) {
+                        if stalledMicros >= maxStallMicros { break }
                         usleep(5_000)
+                        stalledMicros += 5_000
                     } else {
                         break
                     }
@@ -216,12 +225,28 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
         guard masterFileDescriptor >= 0 else { return }
 
         var buffer = [UInt8](repeating: 0, count: 4_096)
+        // Coalesce everything readable in this drain pass into one onOutput
+        // callback. Emitting one callback per 4 KB read means a fast producer
+        // (build logs, `cat` of a big file) causes hundreds of main-thread
+        // hops + per-chunk terminal feeds per second. Bounded so a sustained
+        // firehose still yields data downstream periodically.
+        var pending = Data()
+        let maxCoalescedBytes = 128 * 1024
+
+        func flush() {
+            guard !pending.isEmpty else { return }
+            onOutput?(pending)
+            pending = Data()
+        }
 
         while true {
             let count = read(masterFileDescriptor, &buffer, buffer.count)
 
             if count > 0 {
-                onOutput?(Data(buffer[0..<count]))
+                pending.append(contentsOf: buffer[0..<count])
+                if pending.count >= maxCoalescedBytes {
+                    flush()
+                }
             } else if count == 0 {
                 break
             } else if errno == EINTR {
@@ -232,6 +257,7 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
                 break
             }
         }
+        flush()
     }
 
     private func handleExit() {


### PR DESCRIPTION
Two `TerminiLocalPTYProcess` fixes from running Termini in production in [Belfry](https://github.com/robgough/belfry), a tmux front-end (the contributions mentioned in #2).

**Bounded write back-pressure (deadlock fix).** `send()` retries `EAGAIN`/`EWOULDBLOCK` with `usleep(5ms)` in an unbounded loop. If the PTY's reader never drains — we hit this with a stalled SSH link running under the PTY — the loop runs forever and wedges the serial queue, which then deadlocks any `queue.sync` caller, most notably `terminate()`. In our case that hung app shutdown hard enough that users force-killed the app. The stall is now capped at ~1s, after which the remaining bytes are dropped.

**Coalesced read callbacks (perf).** `drainOutput()` emitted one `onOutput` callback — one main-thread hop plus one terminal feed — per 4 KB `read()`. A fast producer (build logs, `cat` of a big file) caused hundreds of main-thread wakeups per second. All bytes readable in a drain pass are now batched into a single callback, bounded at 128 KB per emission so a sustained firehose still yields downstream periodically.

Both changes are behavior-preserving for well-behaved peers; `swift build` clean on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcSW6KsDkBruL1dPD63rhX