### PR TITLE
Demote the 60 Hz tick timer to a wakeup-driven 1 s backstop

### DIFF
--- a/Sources/Termini/TerminiRuntime.swift
+++ b/Sources/Termini/TerminiRuntime.swift
@@ -13,7 +13,7 @@ final class TerminiRuntime: ObservableObject {
     private let config: ghostty_config_t?
     private(set) var app: ghostty_app_t?
 
-    /// Timer to drive periodic ticks in case the runtime doesn't wake us up.
+    /// Backstop timer in case the runtime doesn’t wake us up (see startTickLoop).
     private var tickTimer: Timer?
     private var notificationTokens: [NSObjectProtocol] = []
     private var hasPendingWakeupTick = false
@@ -191,12 +191,21 @@ final class TerminiRuntime: ObservableObject {
         }
     }
 
+    // The tick loop is a slow backstop, not a 60 Hz drive. Real work is pushed
+    // through `wakeup_cb` → `scheduleWakeupTick()`: libghostty asks for a tick
+    // whenever its mailbox has messages, so ticking blindly at 60 Hz just
+    // burned 60 wakeups + 60 main-queue dispatches per second forever
+    // (blocking App Nap and draining battery while the app sat idle). Keep a
+    // once-a-second safety net with wide tolerance so a missed wakeup can never
+    // wedge the engine, and let the OS coalesce the wakeup with other timers.
     private func startTickLoop() {
-        tickTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
                 self?.tick()
             }
         }
+        timer.tolerance = 0.5
+        tickTimer = timer
     }
 
     private func observeAppFocus() {


### PR DESCRIPTION
`TerminiRuntime` runs an unconditional 60 Hz Timer calling `ghostty_app_tick` (each fire adding a main-queue dispatch) from launch to quit. But the runtime already wires `wakeup_cb` → `scheduleWakeupTick()`, and libghostty invokes it whenever its mailbox has work — so the 60 Hz drive is redundant, and it keeps host apps permanently busy: ~60 wakeups/sec while completely idle, which blocks App Nap.

Measured in [Belfry](https://github.com/robgough/belfry) (one idle surface): this timer was the largest single contributor to a ~22% idle CPU load that dropped to ~0% with this change plus render gating (#see companion PR).

The timer is kept as a once-a-second safety net with 0.5 s tolerance (so the OS coalesces it with other timers) in case a wakeup is ever missed — same belt-and-braces intent, 1/60th the cost.

`swift build` clean on macOS; the surface bring-up path that explicitly calls `runtime.tick()` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcSW6KsDkBruL1dPD63rhX