### PR TITLE
Appearance: extraConfigFilePaths to load ghostty config snippets (colour themes)

### DIFF
--- a/Sources/Termini/TerminiGhosttyConfigFactory.swift
+++ b/Sources/Termini/TerminiGhosttyConfigFactory.swift
@@ -10,8 +10,11 @@ enum TerminiGhosttyConfigFactory {
             return nil
         }
 
+        var modified = false
+
         if let fontSize = appearance.clampedGhosttyFontSize {
             ghostty_config_set_font_size(config, Float(fontSize))
+            modified = true
         }
 
         if let fontFamily = appearance.normalizedFontFamilyName {
@@ -23,7 +26,17 @@ enum TerminiGhosttyConfigFactory {
                 ghostty_config_free(config)
                 return nil
             }
+            modified = true
+        }
 
+        // Load extra config files (e.g. a host app's colour theme snippet). The
+        // C API exposes no per-key colour setter, so colours come in this way.
+        for path in appearance.extraConfigFilePaths {
+            path.withCString { ghostty_config_load_file(config, $0) }
+            modified = true
+        }
+
+        if modified {
             ghostty_config_finalize(config)
         }
 

--- a/Sources/Termini/TerminiTerminalAppearance.swift
+++ b/Sources/Termini/TerminiTerminalAppearance.swift
@@ -216,15 +216,21 @@ public struct TerminiTerminalAppearance: Hashable, Codable, Sendable {
     public var theme: TerminiTerminalTheme?
     public var fontSize: Double?
     public var fontFamily: TerminiTerminalFontFamily?
+    /// Extra libghostty config files to load into each surface's config (applied
+    /// after fonts, before finalize). Host apps can use this to inject colours
+    /// or any other ghostty config keys the C API has no per-key setter for.
+    public var extraConfigFilePaths: [String]
 
     public init(
         theme: TerminiTerminalTheme? = nil,
         fontSize: Double? = nil,
-        fontFamily: TerminiTerminalFontFamily? = nil
+        fontFamily: TerminiTerminalFontFamily? = nil,
+        extraConfigFilePaths: [String] = []
     ) {
         self.theme = theme
         self.fontSize = fontSize
         self.fontFamily = fontFamily
+        self.extraConfigFilePaths = extraConfigFilePaths
     }
 
     public static let `default` = TerminiTerminalAppearance()


### PR DESCRIPTION
GhosttyKit's C API has no per-key colour setters, so an embedding app currently has no way to set a terminal colour theme — surfaces always fall back to libghostty's built-in default.

This adds `TerminiTerminalAppearance.extraConfigFilePaths`: the config factory `ghostty_config_load_file()`s each path after fonts and before the single `finalize`. A host app writes a small ghostty config snippet (colours, palette entries — anything without a C setter) and surfaces pick it up. [Belfry](https://github.com/robgough/belfry) uses this to match its terminal colours to the user's Ghostty theme.

Additive and default-empty, so existing call sites are unaffected. Programs that announce their own colours via OSC still override at runtime, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcSW6KsDkBruL1dPD63rhX