### PR TITLE
Surface: feed terminal output to libghostty off the main thread (deadlock fix)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,77 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssh.git",
+      "state" : {
+        "revision" : "1a915a324afefd4031e396e81a0e210178621be8",
+        "version" : "0.13.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/Termini/TerminiSurfaceView.swift
+++ b/Sources/Termini/TerminiSurfaceView.swift
@@ -56,6 +56,20 @@ public final class SurfaceContainerView: NSView {
     /// un-ticked surface (the tick that drains it also runs on the main thread).
     private var surfaceIOReady = false
     private var pendingOutput = Data()
+    /// Serial queue that hands terminal output to libghostty.
+    ///
+    /// `ghostty_surface_process_output` can block: escape sequences that
+    /// notify the host (set_title, set_mouse_shape from DEC mouse-mode
+    /// toggles, pwd/color changes, …) are pushed onto ghostty's app-wide
+    /// 64-slot mailbox, and when it's full the push waits until
+    /// `ghostty_app_tick` drains it — and that tick runs on the MAIN thread.
+    /// Feeding output on the main thread therefore deadlocks the whole app
+    /// whenever one output burst carries more than 64 such sequences (e.g. a
+    /// tmux pane-split redraw with `mouse on`, which toggles mouse modes
+    /// around every redraw cycle). Upstream ghostty always feeds from a
+    /// dedicated read thread, so we do the same — the serial queue preserves
+    /// byte order, and a full mailbox self-heals on the next main-thread tick.
+    private let outputFeedQueue = DispatchQueue(label: "dev.arach.Termini.surface-output-feed")
     private var renderTimer: Timer?
     private var renderTimerMode: RenderTimerMode?
     private var renderBurstDeadline = Date.distantPast
@@ -391,10 +405,26 @@ public final class SurfaceContainerView: NSView {
             pendingOutput.append(data)
             return
         }
-        data.withUnsafeBytes { buffer in
-            guard let ptr = buffer.bindMemory(to: CChar.self).baseAddress else { return }
-            ghostty_surface_process_output(surface, ptr, UInt(data.count))
+        // Feed off-main (see outputFeedQueue). `guard let self` keeps the view
+        // alive for the duration of the call, so deinit — the only place the
+        // surface is freed — cannot run mid-feed; blocks that only start after
+        // deinit see a nil weak self and skip the freed pointer.
+        outputFeedQueue.async { [weak self] in
+            guard let self else { return }
+            withExtendedLifetime(self) {
+                data.withUnsafeBytes { buffer in
+                    guard let ptr = buffer.bindMemory(to: CChar.self).baseAddress else { return }
+                    ghostty_surface_process_output(surface, ptr, UInt(data.count))
+                }
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.drawAfterRemoteOutput()
+            }
         }
+    }
+
+    private func drawAfterRemoteOutput() {
+        guard let surface else { return }
         ghostty_surface_refresh(surface)
         ghostty_surface_draw(surface)
         requestActiveRenderBurst(duration: 0.35)

--- a/Sources/Termini/TerminiSurfaceView_iOS.swift
+++ b/Sources/Termini/TerminiSurfaceView_iOS.swift
@@ -57,6 +57,20 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
     /// it also runs on the main thread).
     private var surfaceIOReady = false
     private var pendingOutput = Data()
+    /// Serial queue that hands terminal output to libghostty.
+    ///
+    /// `ghostty_surface_process_output` can block: escape sequences that
+    /// notify the host (set_title, set_mouse_shape from DEC mouse-mode
+    /// toggles, pwd/color changes, …) are pushed onto ghostty's app-wide
+    /// 64-slot mailbox, and when it's full the push waits until
+    /// `ghostty_app_tick` drains it — and that tick runs on the MAIN thread.
+    /// Feeding output on the main thread therefore deadlocks the whole app
+    /// whenever one output burst carries more than 64 such sequences (e.g. a
+    /// tmux pane-split redraw with `mouse on`, which toggles mouse modes
+    /// around every redraw cycle). Upstream ghostty always feeds from a
+    /// dedicated read thread, so we do the same — the serial queue preserves
+    /// byte order, and a full mailbox self-heals on the next main-thread tick.
+    private let outputFeedQueue = DispatchQueue(label: "dev.arach.Termini.surface-output-feed")
     private var renderLink: CADisplayLink?
     private weak var controller: TerminiTerminalController?
     private var lastReportedSize: TerminiTerminalSize?
@@ -377,10 +391,26 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
             pendingOutput.append(data)
             return
         }
-        data.withUnsafeBytes { buffer in
-            guard let ptr = buffer.bindMemory(to: CChar.self).baseAddress else { return }
-            ghostty_surface_process_output(surface, ptr, UInt(data.count))
+        // Feed off-main (see outputFeedQueue). `guard let self` keeps the view
+        // alive for the duration of the call, so deinit — the only place the
+        // surface is freed — cannot run mid-feed; blocks that only start after
+        // deinit see a nil weak self and skip the freed pointer.
+        outputFeedQueue.async { [weak self] in
+            guard let self else { return }
+            withExtendedLifetime(self) {
+                data.withUnsafeBytes { buffer in
+                    guard let ptr = buffer.bindMemory(to: CChar.self).baseAddress else { return }
+                    ghostty_surface_process_output(surface, ptr, UInt(data.count))
+                }
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.drawAfterRemoteOutput()
+            }
         }
+    }
+
+    private func drawAfterRemoteOutput() {
+        guard let surface else { return }
         ghostty_surface_refresh(surface)
         ghostty_surface_draw(surface)
         reportDiagnostics()


### PR DESCRIPTION
Another production find from running Termini in [Belfry](https://github.com/robgough/belfry) (see #2, #3): a permanent main-thread deadlock — beachball, force-quit — triggered by ordinary tmux usage.

**The deadlock.** `SurfaceContainerView.processRemoteOutput` calls `ghostty_surface_process_output` on the main thread. Inside ghostty, stream actions that notify the host — `set_title`, `set_mouse_shape` (one per DEC mouse-mode toggle 1000/1002/1003/1006), pwd/color changes — are pushed onto the app-wide 64-slot mailbox (`BlockingQueue(Message, 64)` in ghostty's `App.zig`); when it's full, `surfaceMessageWriter` does `push(.forever)` and blocks until `ghostty_app_tick` drains the mailbox. That tick only ever runs on the main thread — the very thread now parked inside `process_output`. Nothing can unblock it; the wakeup callback's tick is queued behind the blocked main thread.

Any single output burst carrying >64 such sequences deadlocks the app permanently. We hit it reliably with a tmux pane split under `set -g mouse on` (tmux toggles mouse tracking around every redraw cycle, and each toggle flips ghostty's mouse shape → one mailbox message). Hang reports show the main thread in `__ulock_wait2` under `processRemoteOutput` with ghostty's io/renderer threads idle. This is the same deadlock class as the existing `surfaceIOReady` startup buffering, just resurfacing after startup.

**The fix.** Real ghostty always feeds terminal output from a dedicated read thread while the apprt main loop ticks. Surfaces now do the same: a per-surface serial `outputFeedQueue` hands bytes to `ghostty_surface_process_output` (byte order preserved; the feed block retains the view so `deinit` — the only place the surface is freed — can't run mid-call), then hops back to the main thread for the existing refresh/draw (`drawAfterRemoteOutput`). A full mailbox now just stalls the feed queue briefly until the next tick drains it. Same change on macOS and iOS.

**Verified A/B** with TerminiDemo and a fake `$SHELL` that emits 800 `\e[?1003h\e[?1003l` toggles in one burst: the unpatched binary deadlocks instantly with the exact production stack (100% of samples in `__ulock_wait2` under `processRemoteOutput`); the patched binary stays responsive and keeps rendering. `swift build` clean on macOS and iOS.

Note: this touches the same `processRemoteOutput` region as #7, so whichever lands second will need a trivial rebase (in the combined version, the main-thread hop keeps #7's `canRender` gating — happy to update either PR once the other merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHWv6ccUfu4nK3yiGB4ocZ