### PR TITLE
Surface: correct scroll-event semantics (scrolling was far too fast)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,77 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssh.git",
+      "state" : {
+        "revision" : "1a915a324afefd4031e396e81a0e210178621be8",
+        "version" : "0.13.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/Termini/TerminiSurfaceView.swift
+++ b/Sources/Termini/TerminiSurfaceView.swift
@@ -691,12 +691,40 @@ public final class SurfaceContainerView: NSView {
         sendMouseMove(event)
     }
 
+    // The last argument of ghostty_surface_mouse_scroll is NOT keyboard mods:
+    // bit 0 is the precision flag and bits 1–3 the momentum phase (ghostty
+    // src/input/mouse.zig). Passing the keyboard-modifier bitmask made ghostty
+    // treat trackpad *pixel* deltas as discrete wheel ticks, multiplying each
+    // by the cell height — one line scrolled per pixel of finger travel (and
+    // holding shift flipped the precision bit). Mirror ghostty's own AppKit
+    // surface view instead: precise deltas are pixels (with ghostty's 2x feel
+    // multiplier), discrete wheel ticks pass through unscaled, and the
+    // momentum phase is forwarded so inertial scrolling behaves.
     public override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
-        let mods = modsFromFlags(event.modifierFlags)
-        ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, ghostty_input_scroll_mods_t(mods.rawValue))
+        var x = event.scrollingDeltaX
+        var y = event.scrollingDeltaY
+        let precision = event.hasPreciseScrollingDeltas
+        if precision {
+            x *= 2
+            y *= 2
+        }
+        let momentum: ghostty_input_mouse_momentum_e
+        switch event.momentumPhase {
+        case .began: momentum = GHOSTTY_MOUSE_MOMENTUM_BEGAN
+        case .stationary: momentum = GHOSTTY_MOUSE_MOMENTUM_STATIONARY
+        case .changed: momentum = GHOSTTY_MOUSE_MOMENTUM_CHANGED
+        case .ended: momentum = GHOSTTY_MOUSE_MOMENTUM_ENDED
+        case .cancelled: momentum = GHOSTTY_MOUSE_MOMENTUM_CANCELLED
+        case .mayBegin: momentum = GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN
+        default: momentum = GHOSTTY_MOUSE_MOMENTUM_NONE
+        }
+        let scrollMods = ghostty_input_scroll_mods_t(
+            (precision ? 1 : 0) | (Int32(momentum.rawValue) << 1)
+        )
+        ghostty_surface_mouse_scroll(surface, x, y, scrollMods)
         requestActiveRenderBurst(duration: 0.35)
-        logInput("scroll dx=\(event.scrollingDeltaX) dy=\(event.scrollingDeltaY) mods=0x\(String(mods.rawValue, radix: 16))")
+        logInput("scroll dx=\(x) dy=\(y) precision=\(precision) momentum=\(momentum.rawValue)")
     }
 
     private func sendMouse(_ event: NSEvent, state: ghostty_input_mouse_state_e) {


### PR DESCRIPTION
Another one from running Termini in [Belfry](https://github.com/robgough/belfry) (see #3, #8): scrolling in the macOS surface is drastically too fast, because `scrollWheel` passes the wrong thing in `ghostty_surface_mouse_scroll`'s flags argument.

**The bug.** That argument is a *scroll-mods* bitmask — bit 0 is the precision flag, bits 1–3 the momentum phase (`src/input/mouse.zig` in ghostty) — but `scrollWheel` passes the **keyboard** modifier bitmask and never sets precision. Two consequences:

- Trackpad deltas (`scrollingDeltaX/Y` with `hasPreciseScrollingDeltas`) are **pixel** values, but without the precision bit ghostty interprets them as discrete wheel ticks and multiplies each by the cell height — so one pixel of finger travel scrolls a whole line, roughly cell-height× too fast (~30× at typical font sizes).
- Keyboard modifiers land in the wrong bits: shift (bit 0) flips the precision flag, so holding shift while scrolling randomly changes scroll speed; ctrl/alt/super corrupt the momentum phase.

**The fix** mirrors ghostty's own `SurfaceView_AppKit.swift` `scrollWheel`: `hasPreciseScrollingDeltas` sets the precision flag and deltas pass as pixels (with the same 2× feel multiplier ghostty uses), discrete wheel ticks pass through unscaled, and `NSEvent.momentumPhase` is mapped onto `ghostty_input_mouse_momentum_e` so inertial flick-scrolling decays properly instead of replaying raw deltas.

The iOS surface's pan-gesture path already sets the precision bit correctly and is untouched.

Verified by feel in Belfry (trackpad, mouse wheel, and momentum flicks) against Ghostty.app as the reference; `swift build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHWv6ccUfu4nK3yiGB4ocZ