### PR TITLE
Fix universal iOS Simulator GhosttyKit builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ automatically. The helper scripts do the work:
 ./scripts/package-ghosttykit-release.sh
 ```
 
+The build helper applies the tracked patches for the pinned Ghostty release
+from `patches/ghostty/0.1.6/` before compiling. Override that source with
+`--patch-dir` when porting Termini to another Ghostty revision. Release
+packaging also verifies that the iOS Simulator slice is a universal arm64 +
+x86_64 archive, so Intel-compatible artifacts cannot be published accidentally.
+
 ---
 
 ## Good to know

--- a/patches/ghostty/0.1.6/ghostty-ios-simulator-universal.patch
+++ b/patches/ghostty/0.1.6/ghostty-ios-simulator-universal.patch
@@ -1,0 +1,57 @@
+diff --git a/src/build/GhosttyXCFramework.zig b/src/build/GhosttyXCFramework.zig
+index a19dd18af..3d67ac1a1 100644
+--- a/src/build/GhosttyXCFramework.zig
++++ b/src/build/GhosttyXCFramework.zig
+@@ -4,6 +4,7 @@ const std = @import("std");
+ const Config = @import("Config.zig");
+ const SharedDeps = @import("SharedDeps.zig");
+ const GhosttyLib = @import("GhosttyLib.zig");
++const LipoStep = @import("LipoStep.zig");
+ const XCFrameworkStep = @import("XCFrameworkStep.zig");
+ const Target = @import("xcframework.zig").Target;
+
+@@ -35,8 +36,9 @@ pub fn init(
+         }),
+     ));
+
+-    // iOS Simulator
+-    const ios_sim = try GhosttyLib.initStatic(b, &try deps.retarget(
++    // iOS Simulator. Build both architectures so downstream Swift packages can
++    // produce a universal Simulator binary for Apple Silicon and Intel Macs.
++    const ios_sim_arm64 = try GhosttyLib.initStatic(b, &try deps.retarget(
+         b,
+         b.resolveTargetQuery(.{
+             .cpu_arch = .aarch64,
+@@ -52,6 +54,21 @@ pub fn init(
+             .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.apple_a17 },
+         }),
+     ));
++    const ios_sim_x86_64 = try GhosttyLib.initStatic(b, &try deps.retarget(
++        b,
++        b.resolveTargetQuery(.{
++            .cpu_arch = .x86_64,
++            .os_tag = .ios,
++            .os_version_min = Config.osVersionMin(.ios),
++            .abi = .simulator,
++        }),
++    ));
++    const ios_sim_universal = LipoStep.create(b, .{
++        .name = "ghostty-ios-simulator",
++        .out_name = "libghostty-internal-fat.a",
++        .input_a = ios_sim_arm64.output,
++        .input_b = ios_sim_x86_64.output,
++    });
+
+     // Generate a headers directory with only ghostty.h and the module
+     // map. We can't use include/ directly because it also contains the
+@@ -81,9 +98,9 @@ pub fn init(
+                     .dsym = ios.dsym,
+                 },
+                 .{
+-                    .library = ios_sim.output,
++                    .library = ios_sim_universal.output,
+                     .headers = headers,
+-                    .dsym = ios_sim.dsym,
++                    .dsym = null,
+                 },
+             },

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -9,6 +9,7 @@ GHOSTTY_DIR="${GHOSTTY_DIR:-${REPO_ROOT}/vendor/ghostty}"
 GHOSTTY_REPO="${GHOSTTY_REPO:-https://github.com/ghostty-org/ghostty.git}"
 GHOSTTY_REF="${GHOSTTY_REF:-}"
 GHOSTTY_OPTIMIZE="${GHOSTTY_OPTIMIZE:-ReleaseFast}"
+GHOSTTY_PATCH_DIR="${GHOSTTY_PATCH_DIR:-${REPO_ROOT}/patches/ghostty/0.1.6}"
 SHOULD_FETCH=0
 
 usage() {
@@ -20,12 +21,14 @@ Options:
   --ref REF            Git ref to check out before building.
   --fetch              Fetch origin before checking out REF.
   --optimize MODE      Zig optimize mode. Default: ${GHOSTTY_OPTIMIZE}
+  --patch-dir PATH     Patches for the pinned Ghostty source. Default: ${GHOSTTY_PATCH_DIR}
 
 Env:
   GHOSTTY_DIR
   GHOSTTY_REPO
   GHOSTTY_REF
   GHOSTTY_OPTIMIZE
+  GHOSTTY_PATCH_DIR
 EOF
 }
 
@@ -34,6 +37,37 @@ require_cmd() {
     echo "error: missing dependency '$1'" >&2
     exit 1
   fi
+}
+
+apply_patches() {
+  if [[ ! -d "${GHOSTTY_PATCH_DIR}" ]]; then
+    echo "error: Ghostty patch directory does not exist: ${GHOSTTY_PATCH_DIR}" >&2
+    exit 1
+  fi
+
+  local patches=()
+  local patch
+  while IFS= read -r patch; do
+    patches+=("${patch}")
+  done < <(find "${GHOSTTY_PATCH_DIR}" -type f -name '*.patch' -print | LC_ALL=C sort)
+
+  if [[ "${#patches[@]}" -eq 0 ]]; then
+    echo "error: no Ghostty patches found in ${GHOSTTY_PATCH_DIR}" >&2
+    exit 1
+  fi
+
+  for patch in "${patches[@]}"; do
+    if git -C "${GHOSTTY_DIR}" apply --reverse --check "${patch}" >/dev/null 2>&1; then
+      echo "Patch already applied: $(basename "${patch}")"
+      continue
+    fi
+    if ! git -C "${GHOSTTY_DIR}" apply --check "${patch}"; then
+      echo "error: patch does not apply cleanly: ${patch}" >&2
+      exit 1
+    fi
+    git -C "${GHOSTTY_DIR}" apply "${patch}"
+    echo "Applied patch: $(basename "${patch}")"
+  done
 }
 
 ensure_checkout() {
@@ -80,6 +114,10 @@ while [[ $# -gt 0 ]]; do
       GHOSTTY_OPTIMIZE="$2"
       shift 2
       ;;
+    --patch-dir)
+      GHOSTTY_PATCH_DIR="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -97,6 +135,7 @@ require_cmd zig
 
 ensure_checkout
 update_checkout
+apply_patches
 
 (
   cd "${GHOSTTY_DIR}"
@@ -110,5 +149,6 @@ update_checkout
 )
 
 "${REPO_ROOT}/scripts/install-ghosttykit.sh" "${GHOSTTY_DIR}/macos/GhosttyKit.xcframework"
+"${REPO_ROOT}/scripts/verify-ghosttykit.sh"
 
 echo "Built GhosttyKit from $(git -C "${GHOSTTY_DIR}" rev-parse --short HEAD)"

--- a/scripts/install-ghosttykit.sh
+++ b/scripts/install-ghosttykit.sh
@@ -78,8 +78,9 @@ normalize_swiftpm_library_names() {
     mv "${macos_dir}/ghostty-internal.a" "${macos_dir}/libghostty.a"
   fi
 
-  for slice in ios-arm64 ios-arm64-simulator; do
-    local ios_dir="${xcframework_dir}/${slice}"
+  local ios_dir
+  for ios_dir in "${xcframework_dir}/ios-arm64" "${xcframework_dir}"/ios-*-simulator; do
+    [[ -d "${ios_dir}" ]] || continue
     if [[ -f "${ios_dir}/libghostty-internal-fat.a" ]]; then
       mv "${ios_dir}/libghostty-internal-fat.a" "${ios_dir}/libghostty-fat.a"
     fi

--- a/scripts/package-ghosttykit-release.sh
+++ b/scripts/package-ghosttykit-release.sh
@@ -13,6 +13,8 @@ if [[ ! -d "${XCFRAMEWORK_PATH}" ]]; then
   exit 1
 fi
 
+"${REPO_ROOT}/scripts/verify-ghosttykit.sh" "${XCFRAMEWORK_PATH}"
+
 mkdir -p "${OUTPUT_DIR}"
 rm -f "${OUTPUT_PATH}"
 

--- a/scripts/verify-ghosttykit.sh
+++ b/scripts/verify-ghosttykit.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Verify that GhosttyKit can link universal iOS Simulator consumers.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+XCFRAMEWORK_PATH="${1:-${REPO_ROOT}/vendor/ghostty/macos/GhosttyKit.xcframework}"
+
+if [[ ! -d "${XCFRAMEWORK_PATH}" ]]; then
+  echo "error: '${XCFRAMEWORK_PATH}' does not exist or is not a directory" >&2
+  exit 1
+fi
+
+SIMULATOR_DIR="$(find "${XCFRAMEWORK_PATH}" -mindepth 1 -maxdepth 1 -type d -name 'ios-*-simulator' -print -quit)"
+if [[ -z "${SIMULATOR_DIR}" ]]; then
+  echo "error: GhosttyKit has no iOS Simulator slice" >&2
+  exit 1
+fi
+
+SIMULATOR_LIBRARY="${SIMULATOR_DIR}/libghostty-fat.a"
+if [[ ! -f "${SIMULATOR_LIBRARY}" ]]; then
+  echo "error: iOS Simulator slice is missing normalized library ${SIMULATOR_LIBRARY}" >&2
+  exit 1
+fi
+
+ARCHITECTURES="$(lipo -archs "${SIMULATOR_LIBRARY}")"
+for required in arm64 x86_64; do
+  if [[ " ${ARCHITECTURES} " != *" ${required} "* ]]; then
+    echo "error: iOS Simulator slice is missing ${required} (found: ${ARCHITECTURES})" >&2
+    exit 1
+  fi
+done
+
+echo "GhosttyKit iOS Simulator architectures: ${ARCHITECTURES}"


### PR DESCRIPTION
## Summary

- build GhosttyKit's iOS Simulator slice for both arm64 and x86_64, then combine them into a universal archive
- apply Termini's pinned Ghostty patches automatically during framework builds
- validate simulator architectures before packaging a release artifact
- normalize universal simulator XCFramework directories during installation

## Root cause

Ghostty's XCFramework build only emitted an arm64 iOS Simulator archive. Termini also kept its embedding patch in a versioned patch directory that the build script did not apply, while the installer only recognized the previous arm64-only directory name.

Together, that made universal Simulator builds fail and allowed an incomplete release artifact to be packaged.

## Impact

This restores generic/universal iOS Simulator builds, including Intel Mac Simulator support, while preserving the Ghostty embedding APIs Termini depends on. The release verifier now rejects incomplete simulator slices before they are packaged.

## Verification

- `swift test`: 12/12 passing
- confirmed the simulator archive contains both `arm64` and `x86_64`
- confirmed required embedding symbols exist in both architectures
- built OpenScout for a generic iOS Simulator with `ARCHS='arm64 x86_64'`
- confirmed the previous arm64-only 0.1.6 artifact is rejected by the new verifier

The locally generated XCFramework and release ZIP are intentionally not committed.