### PR TITLE
Fix iOS terminal rendering and UTF-8 negotiation

### DIFF
--- a/Sources/Termini/TerminiRuntime.swift
+++ b/Sources/Termini/TerminiRuntime.swift
@@ -47,7 +47,26 @@ final class TerminiRuntime: ObservableObject {
             return
         }
 
+        #if os(iOS)
+        // Ghostty's XDG lookup cannot discover a home directory inside an iOS
+        // app sandbox. Give the synchronous config load an explicit root so
+        // embedded surfaces can honor font maps and other renderer settings.
+        // Restore the process environment immediately afterward because
+        // Termini does not own configuration lookup for the rest of the app.
+        let previousXDGConfigHome = getenv("XDG_CONFIG_HOME").map { String(cString: $0) }
+        let terminiXDGConfigHome = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".config", isDirectory: true)
+            .path
+        setenv("XDG_CONFIG_HOME", terminiXDGConfigHome, 1)
         ghostty_config_load_default_files(config)
+        if let previousXDGConfigHome {
+            setenv("XDG_CONFIG_HOME", previousXDGConfigHome, 1)
+        } else {
+            unsetenv("XDG_CONFIG_HOME")
+        }
+        #else
+        ghostty_config_load_default_files(config)
+        #endif
         ghostty_config_finalize(config)
 
         // Build runtime callbacks.

--- a/Sources/Termini/TerminiRuntime.swift
+++ b/Sources/Termini/TerminiRuntime.swift
@@ -59,6 +59,7 @@ final class TerminiRuntime: ObservableObject {
             .path
         setenv("XDG_CONFIG_HOME", terminiXDGConfigHome, 1)
         ghostty_config_load_default_files(config)
+        ghostty_config_finalize(config)
         if let previousXDGConfigHome {
             setenv("XDG_CONFIG_HOME", previousXDGConfigHome, 1)
         } else {
@@ -66,8 +67,8 @@ final class TerminiRuntime: ObservableObject {
         }
         #else
         ghostty_config_load_default_files(config)
-        #endif
         ghostty_config_finalize(config)
+        #endif
 
         // Build runtime callbacks.
         var runtime = ghostty_runtime_config_s(

--- a/Sources/Termini/TerminiSurfaceView_iOS.swift
+++ b/Sources/Termini/TerminiSurfaceView_iOS.swift
@@ -415,8 +415,11 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
 
         let fontSizeChanged = lastAppliedAppearance.fontSize != terminalAppearance.fontSize
         let fontFamilyChanged = lastAppliedAppearance.fontFamily != terminalAppearance.fontFamily
+        let extraConfigFilePathsChanged = lastAppliedAppearance.extraConfigFilePaths
+            != terminalAppearance.extraConfigFilePaths
         let shouldApplyFontConfig = fontSizeChanged
             || fontFamilyChanged
+            || extraConfigFilePathsChanged
 
         if shouldApplyFontConfig {
             guard let config = runtime.makeSurfaceConfig(for: terminalAppearance) else {

--- a/Sources/Termini/TerminiSurfaceView_iOS.swift
+++ b/Sources/Termini/TerminiSurfaceView_iOS.swift
@@ -111,6 +111,11 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
         super.init(frame: CGRect(x: 0, y: 0, width: 800, height: 600))
         updateBackgroundColor()
         isOpaque = true
+        // Ghostty owns an IOSurfaceLayer below this view. Older known-good
+        // GhosttyKit builds can size that layer to the full drawable before our
+        // first layout pass; clip it so the terminal never paints over sibling
+        // app chrome while synchronizeGhosttyLayerGeometry brings it in sync.
+        clipsToBounds = true
         contentScaleFactor = UIScreen.main.scale
         isMultipleTouchEnabled = true
         addGestureRecognizer(scrollPanGestureRecognizer)
@@ -306,6 +311,12 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
 
         guard let created = ghostty_surface_new(app, &cfg) else { return }
         surface = created
+        // `font_size` is part of the surface creation config, so it is already
+        // active in the initial Ghostty font grid. Treat it as applied here to
+        // avoid immediately replacing that grid with an identical one. Older
+        // Metal renderers can otherwise leave cached cells pointing at the
+        // retired glyph atlas until a full rebuild.
+        lastAppliedAppearance.fontSize = terminalAppearance.fontSize
         synchronizeGhosttyLayerGeometry()
         setSurfaceFocus(true)
         updateSurfaceSize()
@@ -406,7 +417,6 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
         let fontFamilyChanged = lastAppliedAppearance.fontFamily != terminalAppearance.fontFamily
         let shouldApplyFontConfig = fontSizeChanged
             || fontFamilyChanged
-            || (force && terminalAppearance.hasRuntimeFontOverride)
 
         if shouldApplyFontConfig {
             guard let config = runtime.makeSurfaceConfig(for: terminalAppearance) else {
@@ -532,8 +542,9 @@ public final class SurfaceContainerView: UIView, UIKeyInput, UITextInputTraits, 
         ]
 
         for (index, sublayer) in sublayers.prefix(3).enumerated() {
+            let contentsState = sublayer.contents == nil ? "nil" : "set"
             lines.append(
-                "sub[\(index)] \(String(describing: type(of: sublayer))) frame=\(describe(sublayer.frame)) bounds=\(describe(sublayer.bounds)) scale=\(sublayer.contentsScale)"
+                "sub[\(index)] \(String(describing: type(of: sublayer))) frame=\(describe(sublayer.frame)) bounds=\(describe(sublayer.bounds)) scale=\(sublayer.contentsScale) contents=\(contentsState) hidden=\(sublayer.isHidden) opacity=\(sublayer.opacity)"
             )
         }
 

--- a/Sources/TerminiSSH/TerminiSSHSession.swift
+++ b/Sources/TerminiSSH/TerminiSSHSession.swift
@@ -625,6 +625,29 @@ extension TerminiSSHSession {
         }
 
         func channelActive(context: ChannelHandlerContext) {
+            // tmux decides whether a client is UTF-8 capable from the SSH
+            // session locale. Without these requests, servers commonly start
+            // the shell in the C locale and tmux substitutes Nerd Font and
+            // other non-ASCII cells with underscores before bytes ever reach
+            // Termini's renderer.
+            for (name, value) in [
+                ("LANG", "en_US.UTF-8"),
+                ("LC_CTYPE", "en_US.UTF-8"),
+            ] {
+                context.triggerUserOutboundEvent(
+                    SSHChannelRequestEvent.EnvironmentRequest(
+                        wantReply: false,
+                        name: name,
+                        value: value
+                    ),
+                    promise: nil
+                )
+            }
+
+            // RFC 8160 reserves opcode 42 for IUTF8. NIOSSH intentionally
+            // supports raw opcodes so clients can negotiate modes newer than
+            // its named convenience constants.
+            let iutf8 = SSHTerminalModes.Opcode(rawValue: 42)
             let ptyRequest = SSHChannelRequestEvent.PseudoTerminalRequest(
                 wantReply: true,
                 term: term,
@@ -632,7 +655,7 @@ extension TerminiSSHSession {
                 terminalRowHeight: initialRows,
                 terminalPixelWidth: initialPixelWidth,
                 terminalPixelHeight: initialPixelHeight,
-                terminalModes: SSHTerminalModes([:])
+                terminalModes: SSHTerminalModes([iutf8: 1])
             )
 
             let ptyPromise = context.eventLoop.makePromise(of: Void.self)


### PR DESCRIPTION
## Summary

- make Ghostty configuration lookup work inside the iOS app sandbox
- stabilize initial iOS surface rendering and expand renderer diagnostics
- negotiate a UTF-8 SSH locale and IUTF8 PTY mode so tmux preserves Powerline and Nerd Font codepoints

## Validation

- swift test (12 tests passed)
- verified interactively on the iOS 26.5 iPhone 16 Pro Max simulator: connected shell, keyboard input, and Powerline glyphs