### PR TITLE
✨ Add exec-mode SSH workspace configuration

### DIFF
--- a/Sources/TerminiSSH/TerminiConnectionConfig.swift
+++ b/Sources/TerminiSSH/TerminiConnectionConfig.swift
@@ -12,6 +12,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
         case privateKeyPEM
         case term
         case startupCommand
+        case useExecRequest
         case hostKeyPolicy
         case hostKeyFingerprint
     }
@@ -50,6 +51,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
     public var privateKeyPEM: String
     public var term: String
     public var startupCommand: String
+    public var useExecRequest: Bool
     public var hostKeyPolicy: TerminiSSHHostKeyPolicy
     public var hostKeyFingerprint: String
 
@@ -63,6 +65,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
         privateKeyPEM: String = "",
         term: String = "xterm-256color",
         startupCommand: String = "",
+        useExecRequest: Bool = false,
         hostKeyPolicy: TerminiSSHHostKeyPolicy = .trustOnFirstUse,
         hostKeyFingerprint: String = ""
     ) {
@@ -75,6 +78,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
         self.privateKeyPEM = privateKeyPEM
         self.term = term
         self.startupCommand = startupCommand
+        self.useExecRequest = useExecRequest
         self.hostKeyPolicy = hostKeyPolicy
         self.hostKeyFingerprint = hostKeyFingerprint
     }
@@ -91,6 +95,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
         self.privateKeyPEM = try container.decodeIfPresent(String.self, forKey: .privateKeyPEM) ?? ""
         self.term = try container.decodeIfPresent(String.self, forKey: .term) ?? "xterm-256color"
         self.startupCommand = try container.decodeIfPresent(String.self, forKey: .startupCommand) ?? ""
+        self.useExecRequest = try container.decodeIfPresent(Bool.self, forKey: .useExecRequest) ?? false
         self.hostKeyPolicy = try container.decodeIfPresent(TerminiSSHHostKeyPolicy.self, forKey: .hostKeyPolicy) ?? .trustOnFirstUse
         self.hostKeyFingerprint = try container.decodeIfPresent(String.self, forKey: .hostKeyFingerprint) ?? ""
     }
@@ -106,6 +111,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
         try container.encode(privateKeyPEM, forKey: .privateKeyPEM)
         try container.encode(term, forKey: .term)
         try container.encode(startupCommand, forKey: .startupCommand)
+        try container.encode(useExecRequest, forKey: .useExecRequest)
         try container.encode(hostKeyPolicy, forKey: .hostKeyPolicy)
         try container.encode(hostKeyFingerprint, forKey: .hostKeyFingerprint)
     }
@@ -181,6 +187,7 @@ public struct TerminiConnectionConfig: Codable, Equatable, Sendable {
             privateKeyPEM: authenticationMode == .privateKey ? normalizedPrivateKey(privateKeyPEM) : nil,
             term: nonEmpty(term) ?? "xterm-256color",
             startupCommand: nonEmpty(startupCommand),
+            useExecRequest: useExecRequest,
             hostKeyPolicy: hostKeyPolicy,
             hostKeyFingerprint: nonEmpty(hostKeyFingerprint)
         )

--- a/Sources/TerminiSSH/TerminiSSHWorkspace.swift
+++ b/Sources/TerminiSSH/TerminiSSHWorkspace.swift
@@ -30,6 +30,7 @@ public final class TerminiSSHWorkspace {
 
         controller.onSizeChange = { [weak self] size in
             self?.terminalSize = size
+            self?.session?.updateTerminalSize(size)
         }
 
         controller.onDiagnosticsChange = { [weak self] diagnostics in
@@ -91,7 +92,11 @@ public final class TerminiSSHWorkspace {
 
         lastErrorMessage = nil
         statusMessage = "Connecting to \(connection.endpointLabel)…"
-        await ensureSession().connect(configuration: configuration)
+        let session = ensureSession()
+        if let terminalSize {
+            session.updateTerminalSize(terminalSize)
+        }
+        await session.connect(configuration: configuration)
     }
 
     public func disconnect() async {

--- a/Tests/TerminiSSHTests/TerminiConnectionConfigTests.swift
+++ b/Tests/TerminiSSHTests/TerminiConnectionConfigTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import XCTest
+@testable import TerminiSSH
+
+final class TerminiConnectionConfigTests: XCTestCase {
+    func testExecRequestFlowsIntoResolvedSSHConfiguration() throws {
+        let connection = TerminiConnectionConfig(
+            host: "example.com",
+            username: "tester",
+            privateKeyPEM: "private-key",
+            startupCommand: "tmux new -A -s scout",
+            useExecRequest: true
+        )
+
+        let resolved = try XCTUnwrap(connection.resolvedSSHConfiguration())
+
+        XCTAssertEqual(resolved.startupCommand, "tmux new -A -s scout")
+        XCTAssertTrue(resolved.useExecRequest)
+    }
+
+    func testExecRequestRoundTripsThroughCodable() throws {
+        let connection = TerminiConnectionConfig(useExecRequest: true)
+
+        let data = try JSONEncoder().encode(connection)
+        let decoded = try JSONDecoder().decode(TerminiConnectionConfig.self, from: data)
+
+        XCTAssertTrue(decoded.useExecRequest)
+    }
+
+    func testOlderSerializedConnectionDefaultsToShellRequest() throws {
+        let data = Data(#"{"name":"Legacy"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(TerminiConnectionConfig.self, from: data)
+
+        XCTAssertFalse(decoded.useExecRequest)
+    }
+}


### PR DESCRIPTION
## What changed

- expose exec-request startup mode through `TerminiConnectionConfig`
- preserve backward-compatible Codable behavior for stored connections
- propagate live terminal grid changes to the SSH PTY and seed its initial size
- add focused configuration tests

## Why

HudsonTerminal needs the public workspace API to support persistent tmux startup through an SSH exec request without consumers reaching into Termini internals. Propagating resize events also keeps the remote PTY aligned with the rendered grid.

## Validation

- `swift test` (15 tests passed)
- Hudson terminal-enabled suite against this local package (64 XCTest + 137 Swift Testing cases passed)
- OpenScout iOS 26.5 simulator build against the resulting Hudson facade