### PR TITLE
Local pseudo-terminal teardown: avoid serial queue re-entry crash

### DIFF
--- a/Sources/Termini/TerminiLocalPTYProcess.swift
+++ b/Sources/Termini/TerminiLocalPTYProcess.swift
@@ -53,13 +53,16 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
     public var onExit: (@Sendable (Int32) -> Void)?
 
     private let queue = DispatchQueue(label: "dev.arach.Termini.local-pty")
+    private let queueKey = DispatchSpecificKey<Void>()
     private var masterFileDescriptor: Int32 = -1
     private var childPID: pid_t = 0
     private var readSource: DispatchSourceRead?
     private var processSource: DispatchSourceProcess?
     private var lastRequestedSize: Size = .default
 
-    public init() {}
+    public init() {
+        queue.setSpecific(key: queueKey, value: ())
+    }
 
     deinit {
         terminate()
@@ -190,14 +193,22 @@ public final class TerminiLocalPTYProcess: @unchecked Sendable {
     }
 
     public func terminate() {
-        queue.sync {
-            guard childPID > 0 else {
-                cleanup()
-                return
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            terminateOnQueue()
+        } else {
+            queue.sync {
+                terminateOnQueue()
             }
-
-            _ = kill(childPID, SIGTERM)
         }
+    }
+
+    private func terminateOnQueue() {
+        guard childPID > 0 else {
+            cleanup()
+            return
+        }
+
+        _ = kill(childPID, SIGTERM)
     }
 
     private func configureSources() {

--- a/Tests/TerminiTests/TerminiLocalPTYProcessTests.swift
+++ b/Tests/TerminiTests/TerminiLocalPTYProcessTests.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+import Foundation
+import Termini
+import XCTest
+
+final class TerminiLocalPTYProcessTests: XCTestCase {
+    func testProcessCanBeReleasedFromExitCallback() throws {
+        let owner = PTYProcessOwner()
+        try owner.start()
+
+        let deadline = Date().addingTimeInterval(2)
+        while !owner.didReleaseProcess, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        XCTAssertTrue(owner.didReleaseProcess)
+    }
+}
+
+private final class PTYProcessOwner: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: TerminiLocalPTYProcess?
+    private var releasedProcess = false
+
+    var didReleaseProcess: Bool {
+        lock.withLock { releasedProcess }
+    }
+
+    func start() throws {
+        let process = TerminiLocalPTYProcess()
+        process.onExit = { [weak self] _ in
+            self?.releaseProcess()
+        }
+        lock.withLock {
+            self.process = process
+        }
+        try process.start(
+            spec: TerminiProcessSpec(
+                executableURL: URL(fileURLWithPath: "/bin/sleep"),
+                arguments: ["0.05"],
+                workingDirectoryURL: FileManager.default.temporaryDirectory
+            )
+        )
+    }
+
+    private func releaseProcess() {
+        lock.withLock {
+            process = nil
+            releasedProcess = true
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Prevent `TerminiLocalPTYProcess` from synchronously dispatching to its own serial queue during teardown.
- Preserve synchronous termination for callers outside the process queue.
- Add a macOS regression test for callback-driven process release.

## Root cause

The process exit source runs on the local pseudo-terminal queue.
Its exit callback can release the final external process reference.
The process is then destroyed while the exit handler still runs on that queue.

The destructor calls `terminate()`.
The previous implementation called `queue.sync` unconditionally.
Libdispatch traps when code synchronously dispatches to its current serial queue.

This caused a downstream macOS application to exit when it restarted an active shell session.

The fix gives each process queue a specific key.
`terminate()` now runs teardown directly when it already executes on that queue.
External callers keep the existing synchronous behavior.

## Verification

- The new regression test crashed unchanged `main` with XCTest signal code 5.
- The regression test passes with this change.
- `swift build` passes.
- `swift test` passes all 16 tests.
- The downstream built application restarts the real shell session and attaches to its replacement tmux session.
- The downstream application stays open and produces no new crash report.

## Assistance disclosure

OpenAI Codex assisted the diagnosis, implementation, and test preparation.
The change was reproduced and verified against Termini and the downstream built application.
