### PR TITLE
Open detected terminal links with the system application

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ demos, and go deeper.
 - 🐚 **Local shell on macOS** — `TerminiLocalPTYWorkspace` runs a `forkpty`-backed login shell.
 - 🔌 **SSH on macOS + iOS** — `TerminiSSHWorkspace` over SwiftNIO/NIOSSH, with trust-on-first-use host keys.
 - 🎨 **Themes & fonts** — `TerminiTerminalAppearance` for reusable color/font profiles.
+- 🔗 **Clickable links** — open detected URLs and OSC 8 hyperlinks with the platform's default app.
 - 🧩 **Bring-your-own transport** — wire `TerminiTerminalController` to any byte stream you like.
 - 📦 **Zero manual setup** — SwiftPM downloads the prebuilt `GhosttyKit.xcframework` for you.
 

--- a/Sources/Termini/TerminiOpenURLAction.swift
+++ b/Sources/Termini/TerminiOpenURLAction.swift
@@ -1,0 +1,51 @@
+import Foundation
+import GhosttyKit
+
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+enum TerminiOpenURLAction {
+    @MainActor
+    static func handle(_ action: ghostty_action_open_url_s) -> Bool {
+        #if canImport(AppKit)
+        handle(action, using: { NSWorkspace.shared.open($0) })
+        #elseif canImport(UIKit)
+        handle(action, using: { url in
+            UIApplication.shared.open(url)
+            return true
+        })
+        #else
+        false
+        #endif
+    }
+
+    static func handle(
+        _ action: ghostty_action_open_url_s,
+        using opener: (URL) -> Bool
+    ) -> Bool {
+        guard let url = url(from: action) else { return false }
+        return opener(url)
+    }
+
+    static func url(from action: ghostty_action_open_url_s) -> URL? {
+        guard let bytes = action.url,
+              action.len > 0,
+              action.len <= UInt(Int.max) else {
+            return nil
+        }
+
+        let data = Data(bytes: bytes, count: Int(action.len))
+        guard let value = String(data: data, encoding: .utf8), !value.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: value), url.scheme != nil {
+            return url
+        }
+
+        return URL(fileURLWithPath: NSString(string: value).standardizingPath)
+    }
+}

--- a/Sources/Termini/TerminiRuntime.swift
+++ b/Sources/Termini/TerminiRuntime.swift
@@ -141,8 +141,12 @@ final class TerminiRuntime: ObservableObject {
         target: ghostty_target_s,
         action: ghostty_action_s
     ) -> Bool {
-        // For now we acknowledge all actions without special handling.
-        return true
+        switch action.tag {
+        case GHOSTTY_ACTION_OPEN_URL:
+            return TerminiOpenURLAction.handle(action.action.open_url)
+        default:
+            return true
+        }
     }
 
     private static func surfaceView(

--- a/Sources/Termini/TerminiSurfaceView.swift
+++ b/Sources/Termini/TerminiSurfaceView.swift
@@ -4,6 +4,16 @@ import AppKit
 import SwiftUI
 import GhosttyKit
 
+enum TerminiMouseButtonSequence {
+    static func perform(
+        updatePosition: () -> Void,
+        sendButton: () -> Void
+    ) {
+        updatePosition()
+        sendButton()
+    }
+}
+
 /// SwiftUI wrapper that embeds the live Ghostty surface.
 public struct TerminiSurfaceView: NSViewRepresentable {
     private let controller: TerminiTerminalController?
@@ -885,9 +895,11 @@ public final class SurfaceContainerView: NSView {
         guard let surface else { return }
         let mods = modsFromFlags(event.modifierFlags)
         let button = mouseButton(from: event)
-        ghostty_surface_mouse_button(surface, state, button, mods)
+        TerminiMouseButtonSequence.perform(
+            updatePosition: { sendMouseMove(event) },
+            sendButton: { ghostty_surface_mouse_button(surface, state, button, mods) }
+        )
         requestActiveRenderBurst(duration: 0.35)
-        sendMouseMove(event)
     }
 
     private func sendMouseMove(_ event: NSEvent) {

--- a/Sources/Termini/TerminiSurfaceView.swift
+++ b/Sources/Termini/TerminiSurfaceView.swift
@@ -14,6 +14,39 @@ enum TerminiMouseButtonSequence {
     }
 }
 
+enum TerminiModifierKeyEvent {
+    static func action(
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> ghostty_input_action_e? {
+        let flag: NSEvent.ModifierFlags
+        switch keyCode {
+        case 54, 55:
+            flag = .command
+        case 56, 60:
+            flag = .shift
+        case 57:
+            flag = .capsLock
+        case 58, 61:
+            flag = .option
+        case 59, 62:
+            flag = .control
+        case 63:
+            flag = .function
+        default:
+            return nil
+        }
+
+        return modifierFlags.contains(flag) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
+    }
+}
+
+enum TerminiKeyEventText {
+    static func canReadCharacters(from eventType: NSEvent.EventType) -> Bool {
+        eventType == .keyDown || eventType == .keyUp
+    }
+}
+
 /// SwiftUI wrapper that embeds the live Ghostty surface.
 public struct TerminiSurfaceView: NSViewRepresentable {
     private let controller: TerminiTerminalController?
@@ -725,6 +758,17 @@ public final class SurfaceContainerView: NSView {
         sendKeyEvent(event, action: GHOSTTY_ACTION_RELEASE)
     }
 
+    public override func flagsChanged(with event: NSEvent) {
+        guard let action = TerminiModifierKeyEvent.action(
+            keyCode: event.keyCode,
+            modifierFlags: event.modifierFlags
+        ) else {
+            super.flagsChanged(with: event)
+            return
+        }
+        sendKeyEvent(event, action: action)
+    }
+
     public override func performKeyEquivalent(with event: NSEvent) -> Bool {
         guard event.type == .keyDown else { return false }
         guard window?.firstResponder === self else { return false }
@@ -767,6 +811,7 @@ public final class SurfaceContainerView: NSView {
     }
 
     private func translatedText(from event: NSEvent) -> String? {
+        guard TerminiKeyEventText.canReadCharacters(from: event.type) else { return nil }
         guard let chars = event.characters else { return nil }
         if chars.count == 1, let scalar = chars.unicodeScalars.first {
             // Let Ghostty handle control characters itself.
@@ -940,21 +985,27 @@ public final class SurfaceContainerView: NSView {
 
     private func installKeyMonitor() {
         guard keyMonitor == nil else { return }
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp, .flagsChanged]) { [weak self] event in
             guard let self else { return event }
             guard event.window == self.window, self.window?.firstResponder === self else {
                 return event
             }
-            self.logInput("monitor saw \(event.type == .keyDown ? "down" : "up") keyCode=\(event.keyCode) mods=0x\(String(self.modsFromFlags(event.modifierFlags).rawValue, radix: 16)) isKeyWindow=\(self.window?.isKeyWindow == true) firstResponder=\(String(describing: self.window?.firstResponder))")
-            if event.modifierFlags.contains(.command) {
-                return event
-            }
+            self.logInput("monitor saw \(event.type) keyCode=\(event.keyCode) mods=0x\(String(self.modsFromFlags(event.modifierFlags).rawValue, radix: 16)) isKeyWindow=\(self.window?.isKeyWindow == true) firstResponder=\(String(describing: self.window?.firstResponder))")
             switch event.type {
             case .keyDown:
+                if event.modifierFlags.contains(.command) { return event }
                 self.sendKeyEvent(event, action: event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS)
                 return nil
             case .keyUp:
+                if event.modifierFlags.contains(.command) { return event }
                 self.sendKeyEvent(event, action: GHOSTTY_ACTION_RELEASE)
+                return nil
+            case .flagsChanged:
+                guard let action = TerminiModifierKeyEvent.action(
+                    keyCode: event.keyCode,
+                    modifierFlags: event.modifierFlags
+                ) else { return event }
+                self.sendKeyEvent(event, action: action)
                 return nil
             default:
                 return event

--- a/Tests/TerminiTests/TerminiModifierKeyEventTests.swift
+++ b/Tests/TerminiTests/TerminiModifierKeyEventTests.swift
@@ -1,0 +1,46 @@
+#if canImport(AppKit)
+import AppKit
+import GhosttyKit
+import XCTest
+@testable import Termini
+
+final class TerminiModifierKeyEventTests: XCTestCase {
+    func testCommandPressUsesPressAction() {
+        XCTAssertEqual(
+            TerminiModifierKeyEvent.action(
+                keyCode: 55,
+                modifierFlags: [.command]
+            ),
+            GHOSTTY_ACTION_PRESS
+        )
+    }
+
+    func testCommandReleaseUsesReleaseAction() {
+        XCTAssertEqual(
+            TerminiModifierKeyEvent.action(
+                keyCode: 55,
+                modifierFlags: []
+            ),
+            GHOSTTY_ACTION_RELEASE
+        )
+    }
+
+    func testRightCommandUsesCommandFlag() {
+        XCTAssertEqual(
+            TerminiModifierKeyEvent.action(
+                keyCode: 54,
+                modifierFlags: [.command]
+            ),
+            GHOSTTY_ACTION_PRESS
+        )
+    }
+
+    func testModifierChangeDoesNotReadKeyCharacters() {
+        XCTAssertFalse(TerminiKeyEventText.canReadCharacters(from: .flagsChanged))
+    }
+
+    func testKeyDownCanReadKeyCharacters() {
+        XCTAssertTrue(TerminiKeyEventText.canReadCharacters(from: .keyDown))
+    }
+}
+#endif

--- a/Tests/TerminiTests/TerminiMouseButtonSequenceTests.swift
+++ b/Tests/TerminiTests/TerminiMouseButtonSequenceTests.swift
@@ -1,0 +1,17 @@
+#if canImport(AppKit)
+import XCTest
+@testable import Termini
+
+final class TerminiMouseButtonSequenceTests: XCTestCase {
+    func testUpdatesPositionBeforeSendingButton() {
+        var events: [String] = []
+
+        TerminiMouseButtonSequence.perform(
+            updatePosition: { events.append("position") },
+            sendButton: { events.append("button") }
+        )
+
+        XCTAssertEqual(events, ["position", "button"])
+    }
+}
+#endif

--- a/Tests/TerminiTests/TerminiOpenURLActionTests.swift
+++ b/Tests/TerminiTests/TerminiOpenURLActionTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import GhosttyKit
+@testable import Termini
+
+final class TerminiOpenURLActionTests: XCTestCase {
+    func testHandleOpensExplicitURL() {
+        withAction("https://github.com/arach/Termini/pull/13") { action in
+            var openedURL: URL?
+
+            let handled = TerminiOpenURLAction.handle(action) { url in
+                openedURL = url
+                return true
+            }
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(openedURL?.absoluteString, "https://github.com/arach/Termini/pull/13")
+        }
+    }
+
+    func testHandleUsesOnlyReportedByteLength() {
+        let expected = "https://example.com"
+
+        withAction("\(expected)/ignored", length: expected.utf8.count) { action in
+            let url = TerminiOpenURLAction.url(from: action)
+
+            XCTAssertEqual(url?.absoluteString, expected)
+        }
+    }
+
+    func testHandleConvertsPathToFileURL() {
+        withAction("~/Documents/session.log") { action in
+            let url = TerminiOpenURLAction.url(from: action)
+
+            XCTAssertTrue(url?.isFileURL == true)
+            XCTAssertEqual(url?.lastPathComponent, "session.log")
+        }
+    }
+
+    func testHandleRejectsMissingURL() {
+        let action = ghostty_action_open_url_s(
+            kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+            url: nil,
+            len: 0
+        )
+
+        XCTAssertFalse(TerminiOpenURLAction.handle(action) { _ in true })
+    }
+
+    func testHandleRejectsInvalidUTF8() {
+        let bytes: [UInt8] = [0xFF]
+
+        bytes.withUnsafeBytes { buffer in
+            let action = ghostty_action_open_url_s(
+                kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+                url: buffer.bindMemory(to: CChar.self).baseAddress,
+                len: UInt(bytes.count)
+            )
+
+            XCTAssertFalse(TerminiOpenURLAction.handle(action) { _ in true })
+        }
+    }
+
+    private func withAction(
+        _ value: String,
+        length: Int? = nil,
+        perform: (ghostty_action_open_url_s) -> Void
+    ) {
+        let bytes = Array(value.utf8)
+
+        bytes.withUnsafeBytes { buffer in
+            let action = ghostty_action_open_url_s(
+                kind: GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
+                url: buffer.bindMemory(to: CChar.self).baseAddress,
+                len: UInt(length ?? bytes.count)
+            )
+
+            perform(action)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Handle libghostty's `OPEN_URL` runtime action.
- Open detected URLs and OSC 8 hyperlinks with the platform's default application.
- Decode the length-delimited C payload without requiring a null terminator.
- Treat scheme-free values as file paths, matching Ghostty's macOS behavior.
- Document clickable link support.

## Tests

- `swift test` passes 20 tests.
- The new URL tests cover web URLs, file paths, byte lengths, missing values, and invalid UTF-8.
- The iOS demo build could not start because this machine does not have the iOS 26.5 platform installed.

## AI Assistance

Codex assisted with implementation and test development. I reviewed and tested the changes.
