### PR TITLE
Write OSC 52 text to the macOS system clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ demos, and go deeper.
 - 🐚 **Local shell on macOS** — `TerminiLocalPTYWorkspace` runs a `forkpty`-backed login shell.
 - 🔌 **SSH on macOS + iOS** — `TerminiSSHWorkspace` over SwiftNIO/NIOSSH, with trust-on-first-use host keys.
 - 🎨 **Themes & fonts** — `TerminiTerminalAppearance` for reusable color/font profiles.
+- 📋 **System clipboard writes on macOS** — OSC 52 writes text when the Ghostty policy allows it.
 - 🧩 **Bring-your-own transport** — wire `TerminiTerminalController` to any byte stream you like.
 - 📦 **Zero manual setup** — SwiftPM downloads the prebuilt `GhosttyKit.xcframework` for you.
 

--- a/Sources/Termini/TerminiRuntime.swift
+++ b/Sources/Termini/TerminiRuntime.swift
@@ -86,7 +86,14 @@ final class TerminiRuntime: ObservableObject {
             confirm_read_clipboard_cb: { userdata, string, state, _ in
                 TerminiRuntime.confirmReadClipboard(userdata, string: string, state: state)
             },
-            write_clipboard_cb: { _, _, _, _, _ in
+            write_clipboard_cb: { userdata, location, content, count, requiresConfirmation in
+                TerminiRuntime.writeClipboard(
+                    userdata,
+                    location: location,
+                    content: content,
+                    count: count,
+                    requiresConfirmation: requiresConfirmation
+                )
             },
             write_to_host_cb: { surfaceUserdata, bytes, count in
                 TerminiRuntime.writeToHost(surfaceUserdata, bytes, count)
@@ -174,6 +181,24 @@ final class TerminiRuntime: ObservableObject {
         guard let view = surfaceView(from: userdata),
               let string else { return }
         view.completeClipboardRequest(String(cString: string), state: state, confirmed: true)
+        #endif
+    }
+
+    private static func writeClipboard(
+        _ userdata: UnsafeMutableRawPointer?,
+        location: ghostty_clipboard_e,
+        content: UnsafePointer<ghostty_clipboard_content_s>?,
+        count: Int,
+        requiresConfirmation: Bool
+    ) {
+        #if canImport(AppKit)
+        guard let view = surfaceView(from: userdata) else { return }
+        view.writeClipboard(
+            location: location,
+            content: content,
+            count: count,
+            requiresConfirmation: requiresConfirmation
+        )
         #endif
     }
 

--- a/Sources/Termini/TerminiSurfaceView.swift
+++ b/Sources/Termini/TerminiSurfaceView.swift
@@ -1000,6 +1000,35 @@ public final class SurfaceContainerView: NSView {
         }
     }
 
+    func writeClipboard(
+        location: ghostty_clipboard_e,
+        content: UnsafePointer<ghostty_clipboard_content_s>?,
+        count: Int,
+        requiresConfirmation: Bool
+    ) {
+        guard !requiresConfirmation,
+              let pasteboard = pasteboard(for: location),
+              let content,
+              count > 0 else {
+            return
+        }
+
+        let entries = (0..<count).compactMap { index -> ClipboardEntry? in
+            let item = content[index]
+            guard let mime = item.mime.flatMap(String.init(validatingCString:)),
+                  let value = item.data.flatMap(String.init(validatingCString:)) else {
+                return nil
+            }
+            return ClipboardEntry(type: pasteboardType(for: mime), value: value)
+        }
+        guard !entries.isEmpty else { return }
+
+        pasteboard.declareTypes(entries.map(\.type), owner: nil)
+        for entry in entries {
+            pasteboard.setString(entry.value, forType: entry.type)
+        }
+    }
+
     private func pasteFromClipboard() -> Bool {
         guard let surface else { return false }
         let action = "paste_from_clipboard"
@@ -1030,6 +1059,15 @@ public final class SurfaceContainerView: NSView {
 
         return pasteboard.string(forType: .string)
     }
+
+    private func pasteboardType(for mime: String) -> NSPasteboard.PasteboardType {
+        mime == "text/plain" ? .string : NSPasteboard.PasteboardType(mime)
+    }
+}
+
+private struct ClipboardEntry {
+    let type: NSPasteboard.PasteboardType
+    let value: String
 }
 
 private extension TerminiTerminalTheme {

--- a/Tests/TerminiTests/TerminiClipboardTests.swift
+++ b/Tests/TerminiTests/TerminiClipboardTests.swift
@@ -1,0 +1,85 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Termini
+
+final class TerminiClipboardTests: XCTestCase {
+    @MainActor private static var retainedFixtures: [(NSView, NSWindow)] = []
+
+    @MainActor
+    func testOSC52WritesTextToSystemClipboard() async throws {
+        _ = NSApplication.shared
+        let pasteboard = NSPasteboard.general
+        let snapshot = PasteboardSnapshot(pasteboard: pasteboard)
+        defer {
+            snapshot.restore(to: pasteboard)
+        }
+
+        let controller = TerminiTerminalController()
+        let terminalView = TerminiTerminalView(
+            controller: controller,
+            showsSystemKeyboard: false
+        )
+        let hostingView = NSHostingView(rootView: terminalView)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 800, height: 500)
+
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        try await Task.sleep(for: .milliseconds(250))
+
+        let expectedClipboard = "termini-osc52-\(UUID().uuidString)"
+        let encodedClipboard = Data(expectedClipboard.utf8).base64EncodedString()
+        controller.processRemoteOutput(
+            Data("\u{1B}]52;c;\(encodedClipboard)\u{07}".utf8)
+        )
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while pasteboard.string(forType: .string) != expectedClipboard,
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertTrue(
+            pasteboard.string(forType: .string) == expectedClipboard,
+            "OSC 52 did not update the system clipboard."
+        )
+        Self.retainedFixtures.append((hostingView, window))
+    }
+}
+
+private struct PasteboardSnapshot {
+    private let items: [[NSPasteboard.PasteboardType: Data]]
+
+    init(pasteboard: NSPasteboard) {
+        items = pasteboard.pasteboardItems?.map { item in
+            Dictionary(
+                uniqueKeysWithValues: item.types.compactMap { type in
+                    item.data(forType: type).map { (type, $0) }
+                }
+            )
+        } ?? []
+    }
+
+    func restore(to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        let pasteboardItems = items.map { itemData in
+            let item = NSPasteboardItem()
+            for (type, data) in itemData {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        if !pasteboardItems.isEmpty {
+            pasteboard.writeObjects(pasteboardItems)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Connect libghostty's clipboard write callback to the macOS system clipboard.
- Write OSC 52 text only when the Ghostty policy permits the write without confirmation.
- Keep requests that need confirmation blocked until Termini provides a confirmation interface.
- Document macOS system clipboard write support.

## Root cause

Termini registered `write_clipboard_cb`, but the callback discarded every request.
Terminal programs could emit a valid OSC 52 write, but the text never reached `NSPasteboard`.

This affected tools such as Helix when tmux used OSC 52 to copy a selection.

## Security

Ghostty evaluates its clipboard write policy before it calls the runtime callback.
Termini writes only when `requiresConfirmation` is false.
Termini does not approve confirmation-required writes without user input.

## Verification

- The new OSC 52 regression test fails on unchanged `main`.
- `swift test` passes all 16 tests with this change.
- A downstream macOS app copies a real Helix selection through tmux to the system clipboard.
- The regression test restores the previous system clipboard contents.

## AI assistance

OpenAI Codex assisted the diagnosis, implementation, and test preparation.
I reviewed and tested the changes.
